### PR TITLE
sequoia-chameleon 0.11.2 (new formula)

### DIFF
--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -12,7 +12,6 @@ class SequoiaChameleon < Formula
   depends_on "openssl@3"
 
   uses_from_macos "bzip2"
-  uses_from_macos "iconv"
   uses_from_macos "sqlite"
 
   def install
@@ -42,11 +41,13 @@ class SequoiaChameleon < Formula
     EOS
     begin
       mkdir ".gnupg"
-      chmod 0o700, ".gnupg"
+      chmod 0700, ".gnupg"
       system bin / "gpg-sq", "--batch", "--gen-key", "batch.gpg"
       (testpath / "test.txt").write "Hello World!"
-      system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient", "bob@foo.bar", "--output", "test.gpg", "test.txt"
-      system bin / "gpg-sq", "--verbose", "--decrypt", "--local-user", "bob@foo.bar", "--output", "test2.txt", "test.gpg"
+      system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient",
+        "bob@foo.bar", "--output", "test.gpg", "test.txt"
+      system bin / "gpg-sq", "--verbose", "--decrypt", "--local-user", "bob@foo.bar", "--output", "test2.txt",
+        "test.gpg"
       (testpath / "test.txt").read == (testpath / "test2.txt").read
     end
   end

--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -7,6 +7,9 @@ class SequoiaChameleon < Formula
 
   depends_on "rust" => :build
 
+  # the test suite needs a `gpgconf` executable in path
+  depends_on "gpg" => :test
+
   depends_on "gmp"
   depends_on "nettle"
   depends_on "openssl@3"
@@ -40,7 +43,7 @@ class SequoiaChameleon < Formula
       %commit
     EOS
     begin
-      mkdir_p testpath / ".gnupg" / "openpgp-revocs.d"
+      mkdir_p testpath / ".gnupg"
       chmod 0700, ".gnupg"
 
       ENV["SEQUOIA_GPG_CHAMELEON_LOG_INVOCATIONS"] = "/tmp/chameleon.log"

--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -42,7 +42,7 @@ class SequoiaChameleon < Formula
     begin
       mkdir ".gnupg"
       chmod 0700, ".gnupg"
-      system bin / "gpg-sq", "--batch", "--gen-key", "batch.gpg"
+      system bin / "gpg-sq", "--verbose", "--batch", "--gen-key", "batch.gpg"
       (testpath / "test.txt").write "Hello World!"
       system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient",
         "bob@foo.bar", "--output", "test.gpg", "test.txt"

--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -8,7 +8,7 @@ class SequoiaChameleon < Formula
   depends_on "rust" => :build
 
   # the test suite needs a `gpgconf` executable in path
-  depends_on "gpg" => :test
+  depends_on "gnupg" => :test
 
   depends_on "gmp"
   depends_on "nettle"
@@ -43,16 +43,15 @@ class SequoiaChameleon < Formula
       %commit
     EOS
     begin
-      mkdir_p testpath / ".gnupg"
+      mkdir testpath / ".gnupg"
       chmod 0700, ".gnupg"
 
-      ENV["SEQUOIA_GPG_CHAMELEON_LOG_INVOCATIONS"] = "/tmp/chameleon.log"
       system bin / "gpg-sq", "--verbose", "--batch", "--gen-key", "batch.gpg"
       (testpath / "test.txt").write "Hello World!"
       system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient",
-        "bob@foo.bar", "--output", "test.gpg", "test.txt"
+"bob@foo.bar", "--output", "test.gpg", "test.txt"
       system bin / "gpg-sq", "--verbose", "--decrypt", "--local-user", "bob@foo.bar", "--output", "test2.txt",
-        "test.gpg"
+"test.gpg"
       (testpath / "test.txt").read == (testpath / "test2.txt").read
     end
   end

--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -1,0 +1,53 @@
+class SequoiaChameleon < Formula
+  desc "Reimplementation of gpg and gpgv using Sequoia"
+  homepage "https://sequoia-pgp.org"
+  url "https://gitlab.com/sequoia-pgp/sequoia-chameleon-gnupg/-/archive/v0.11.2/sequoia-chameleon-gnupg-v0.11.2.tar.gz"
+  sha256 "e254146d42facc704bd68c33fec174f15edf6921dd1bc578b37c93ae61c99781"
+  license "GPL-3.0-or-later"
+
+  depends_on "rust" => :build
+
+  depends_on "gmp"
+  depends_on "nettle"
+  depends_on "openssl@3"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "iconv"
+  uses_from_macos "sqlite"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath / "batch.gpg").write <<~EOS
+      Key-Type: RSA
+      Key-Length: 4096
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Name-Real: Alice
+      Name-Email: alice@foo.bar
+      Expire-Date: 1d
+      %no-protection
+      %commit
+      Key-Type: RSA
+      Key-Length: 4096
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Name-Real: Bob
+      Name-Email: bob@foo.bar
+      Expire-Date: 1d
+      %no-protection
+      %commit
+    EOS
+    begin
+      mkdir ".gnupg"
+      chmod 0o700, ".gnupg"
+      system bin / "gpg-sq", "--batch", "--gen-key", "batch.gpg"
+      (testpath / "test.txt").write "Hello World!"
+      system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient", "bob@foo.bar", "--output", "test.gpg", "test.txt"
+      system bin / "gpg-sq", "--verbose", "--decrypt", "--local-user", "bob@foo.bar", "--output", "test2.txt", "test.gpg"
+      (testpath / "test.txt").read == (testpath / "test2.txt").read
+    end
+  end
+end

--- a/Formula/sequoia-chameleon.rb
+++ b/Formula/sequoia-chameleon.rb
@@ -40,8 +40,10 @@ class SequoiaChameleon < Formula
       %commit
     EOS
     begin
-      mkdir ".gnupg"
+      mkdir_p testpath / ".gnupg" / "openpgp-revocs.d"
       chmod 0700, ".gnupg"
+
+      ENV["SEQUOIA_GPG_CHAMELEON_LOG_INVOCATIONS"] = "/tmp/chameleon.log"
       system bin / "gpg-sq", "--verbose", "--batch", "--gen-key", "batch.gpg"
       (testpath / "test.txt").write "Hello World!"
       system bin / "gpg-sq", "--verbose", "--sign", "--encrypt", "--local-user", "alice@foo.bar", "--recipient",


### PR DESCRIPTION
Sequoia's drop-in replacement for `gpg`.  Not yet feature-complete, and not sufficiently popular to qualify for `homebrew/core`, so I put it in a tap.